### PR TITLE
recurrent_group for pytorch

### DIFF
--- a/flare/framework/recurrent.py
+++ b/flare/framework/recurrent.py
@@ -1,0 +1,144 @@
+import torch
+import numpy as np
+
+
+def make_hierarchy_of_tensors(data, dtype, device, shape):
+    """
+    Given a (nested) list of arrays (`data`), each with a `shape`,
+    return a (nested) list of torch tensors such that only the leaf nodes that
+    all should matche `shape` will be converted. The other intermediate nodes
+    keep the same (still list).
+    """
+    assert hasattr(data, "__len__"), "no leaf with the shape is found!"
+    try:
+        np_array = np.array(data)
+        if len(np_array.shape) == len(shape) + 1:  ## plus batch size
+            if list(np_array.shape[1:]) == list(shape):
+                ## we have reached a leaf node
+                return torch.from_numpy(np_array.astype(dtype)).to(device)
+    except:
+        ## conversion fails
+        ## recursively traverse down the hierarchy
+        pass
+
+    return [make_hierarchy_of_tensors(d, dtype, device, shape) for d in data]
+
+
+def batch_size(b):
+    """
+    Obtain the length of a batch. The batch can be a tensor or a list.
+    """
+    return (b.size()[0] if isinstance(b, torch.Tensor) else len(b))
+
+
+def transpose(hier_tensors):
+    """
+    Given a hierarchy of tensors, at the highest level we transpose the structure.
+    Namely, we make a frame by taking out the i-th child of each node at the current level.
+    """
+    assert isinstance(hier_tensors,
+                      list) and hier_tensors, "must be a non-empty list!"
+    leaf_child = isinstance(hier_tensors[0], torch.Tensor)
+    ### check all the children's type
+    for node in hier_tensors:
+        assert isinstance(node, torch.Tensor) == leaf_child, \
+            "all children must have the same type!"
+
+    ## we require that the children at each level are sorted in the
+    ## descending order of their lengths
+    seq_lens = []
+    for node in hier_tensors:
+        seq_lens.append(batch_size(node))
+
+    assert seq_lens == sorted(seq_lens, reverse=True), \
+        "please sort the sequences in the descending order of sequence lengths!"
+
+    max_len = seq_lens[0]
+    transposed = []
+    for i in range(max_len):
+        if leaf_child:
+            new_node = torch.stack(
+                [t[i] for t in hier_tensors if i < t.size()[0]])
+        else:
+            new_node = [node[i] for node in hier_tensors if i < len(node)]
+        transposed.append(new_node)
+    return transposed
+
+
+def recurrent_group(seq_inputs, insts, init_states, step_func):
+    """
+    Strip a sequence level and apply the stripped inputs to `step_func`
+    provided the user.
+
+    seq_inputs: collection of sequences, each being either a tensor or a list
+    insts: collection of static instances, each being a tensor
+    init_states: collection of initial states, each being a tensor
+    """
+    assert isinstance(seq_inputs, list)
+    assert isinstance(insts, list)
+    assert isinstance(init_states, list)
+
+    ## We might have multiple sequential inputs.
+    ## (For example,
+    ##   the first sequential input is a collection of temporal sequences of sentences,
+    ##   the second sequential input is a collection of temporal sequences of images, and
+    ##   each sentence is paired with an image.)
+    ## In this scenario, after the transpose the numbers of frames should be
+    ## the same.
+
+    ## If two sequential inputs cannot satisfy this requirement, then consider separating
+    ## them by calling recurrent_group individually, because there cannot be any interaction
+    ## between them at every time step.
+
+    ## The following block checks this requirement.
+    def check_num_sequences_equal(seq_inputs):
+        assert len(set([len(si) for si in seq_inputs])) == 1, \
+            "Each sequential input should have the same number of sequences!"
+
+    def check_sequences_aligned(seq_inputs):
+        len_mat = [map(batch_size, si) for si in seq_inputs]
+        trans_len_mat = zip(*len_mat)
+        assert (not (False in [len(set(r)) == 1 for r in trans_len_mat])), \
+            "Some sequences are not temporally aligned!"
+
+    check_num_sequences_equal(seq_inputs)
+    check_sequences_aligned(seq_inputs)
+
+    for inst in insts:
+        assert isinstance(inst, torch.Tensor)
+        assert len(seq_inputs[0]) == inst.size()[0], \
+            "The number of static instances should be the same with the number of sequences!"
+    for init_state in init_states:
+        assert isinstance(init_state, torch.Tensor)
+        assert len(seq_inputs[0]) == init_state.size()[0], \
+            "The number of initial states should be the same with the number of sequences!"
+
+    ## call the step function frame by frame
+    frames_n = max(map(batch_size, seq_inputs[0]))
+    seq_frames = []
+    for seq in seq_inputs:
+        seq_frames.append(transpose(seq))
+    states = init_states
+    transposed_out_frames = []
+    for i in range(frames_n):
+        in_frames = []
+        frame_size = None
+        for frs in seq_frames:
+            size = batch_size(frs[i])
+            if frame_size is None:
+                frame_size = size
+            else:
+                assert frame_size == size, "all the input frames must have the same size!!"
+            in_frames.append(frs[i])
+
+        ## we should cut the insts and states by the frame_size
+        states = [s[:frame_size] for s in states]
+        insts = [i[:frame_size] for i in insts]
+        out_frames, states = step_func(*(in_frames + insts + states))
+        out_frames += states
+        transposed_out_frames.append(out_frames)
+
+    seq_outs = [
+        transpose(list(frames)) for frames in zip(*transposed_out_frames)
+    ]
+    return seq_outs

--- a/flare/framework/tests/test_recurrent.py
+++ b/flare/framework/tests/test_recurrent.py
@@ -9,7 +9,10 @@ def tensor_lists_equal(t1, t2):
     Given two (nested) lists of tensors, return whether they are equal.
     """
     if isinstance(t1, torch.Tensor) and isinstance(t2, torch.Tensor):
-        return bool((t1 == t2).all().item())
+        ## round in case of floating errors
+        t1 = np.round(t1.data.numpy(), decimals=5)
+        t2 = np.round(t2.data.numpy(), decimals=5)
+        return np.array_equal(t1, t2)
 
     assert isinstance(t1, list)
     assert isinstance(t2, list)
@@ -32,49 +35,48 @@ class TestHierarchyTensorTranspose(unittest.TestCase):
 
 
 class TestRecurrentGroup(unittest.TestCase):
-    def test_recurrent_group(self):
+    def test_multi_sequential_inputs(self):
         ## we first make a batch of temporal sequences of sentences
         ## Let's suppose that each word has a 1d embedding
         sentences = [## temporal sequence 1
                      [[[0.3], [0.4], [0.5]],          ## sentence 1
-                      [[0.2], [0.2]],                 ## sentence 2
-                      [[1.0], [0.2], [0.4], [0.5]]],  ## sentence 3
+                      [[0.1], [0.2]]],                ## sentence 2
                      ## temporal sequence 2
-                     [[[0.3], [0.4], [0.5]],          ## sentence 4
-                      [[0.1], [0.2]]]                 ## sentence 5
+                     [[[0.3], [0.4], [0.5]],          ## sentence 3
+                      [[0.2], [0.2]],                 ## sentence 4
+                      [[1.0], [0.2], [0.4], [0.5]]],  ## sentence 5
         ]
         sentence_tensors = rc.make_hierarchy_of_tensors(sentences, "float32",
                                                         "cpu", [1])
 
         ## we then make a batch of temporal sequences of images
         images = [## temporal sequence 1
-                  [[0, 1],                     ## image 1
-                   [1, 0],                     ## image 2
-                   [1, 1]],                    ## image 3
+                  [[0.1, 0.3],                 ## image 1
+                   [0, -1]],                   ## image 2
                   ## temporal sequence 2
-                  [[0.1, 0.3],                 ## image 4
-                   [0, -1]]                    ## image 5
+                  [[0, 1],                     ## image 3
+                   [1, 0],                     ## image 4
+                   [1, 1]],                    ## image 5
         ]
         image_tensors = rc.make_hierarchy_of_tensors(images, "float32", "cpu",
                                                      [2])
 
         states = [
-            [-1, -2, -3, -4],  ## temporal sequence 1
-            [-2, -4, -6, -8]  ## temporal sequence 2
+            [-2, -4, -6, -8],  ## temporal sequence 1
+            [-1, -2, -3, -4],  ## temporal sequence 2
         ]
         state_tensors = rc.make_hierarchy_of_tensors(states, "float32", "cpu",
                                                      [4])
 
         def step_func(sentence, image, state):
             """
-            We have no `insts` and `states`
+            We compute the first output by doing outer product between the
+            average word embedding and the image embedding.
+            We compute the second output by adding the average word embedding
+            and the average image embedding.
+            We directly add the state mean value to the output
+            and update the state by multiplying it with -1.
             """
-            ## We compute the first output by doing outer product between the
-            ## average word embedding and the image embedding.
-            ## We compute the second output by adding the average word embedding
-            ## and the average image embedding.
-            ## We directly add the state mean value to the output
-            ## and update the state by multiplying it with -1.
             assert isinstance(sentence, list)
             assert isinstance(image, torch.Tensor)
             assert isinstance(state, torch.Tensor)
@@ -95,20 +97,102 @@ class TestRecurrentGroup(unittest.TestCase):
                 outs,
                 [
                     [
+                        torch.tensor([[-4.9600, -4.8800], [5.0000, 4.8500]]),
                         torch.tensor([[-2.5000, -2.1000], [2.7000, 2.5000],
-                                      [-1.9750, -1.9750]]),
-                        torch.tensor([[-4.9600, -4.8800], [5.0000, 4.8500]])
+                                      [-1.9750, -1.9750]])
                     ],  ## out1
                     [
-                        torch.tensor([[-1.6000], [3.2000], [-0.9750]]),
-                        torch.tensor([[-4.4000], [4.6500]])
+                        torch.tensor([[-4.4000], [4.6500]]), torch.tensor(
+                            [[-1.6000], [3.2000], [-0.9750]])
                     ],  ## out2
                     [
+                        torch.tensor([[2., 4., 6., 8.], [-2., -4., -6., -8.]]),
                         torch.tensor([[1., 2., 3., 4.], [-1., -2., -3., -4.],
-                                      [1., 2., 3., 4.]]),
-                        torch.tensor([[2., 4., 6., 8.], [-2., -4., -6., -8.]])
+                                      [1., 2., 3., 4.]])
                     ]  ## state
                 ]))
+
+    def test_hierchical_sequences(self):
+        sentences = [## temporal sequence 1
+                     [[[0.3], [0.4], [0.5]],          ## sentence 1
+                      [[0.1], [0.2]]],                ## sentence 2
+                     ## temporal sequence 2
+                     [[[0.3], [0.4], [0.5]],          ## sentence 3
+                      [[0.2], [0.2]],                 ## sentence 4
+                      [[1.0], [0.2], [0.4], [0.5]]],  ## sentence 5
+        ]
+        sentence_tensors = rc.make_hierarchy_of_tensors(sentences, "float32",
+                                                        "cpu", [1])
+
+        sentence_states = [
+            [-2, -4, -6, -8],  ## temporal sequence 1
+            [-1, -2, -3, -4],  ## temporal sequence 2
+        ]
+        sentence_state_tensors = rc.make_hierarchy_of_tensors(
+            sentence_states, "float32", "cpu", [4])
+
+        word_states = [
+            [1.0, 1.0],  ## sentence 1
+            [-1.0, -1.0],  ## sentence 3
+        ]
+        word_state_tensors = rc.make_hierarchy_of_tensors(
+            word_states, "float32", "cpu", [2])
+
+        ## This hierarchical function does the following things:
+        ## 1. For each word in each sentence, we add the average word state
+        ##    to the word embedding, and the word state keeps the same all the time
+        ## 2. We take the last output of the words and the word states
+        ## 3. In the higher level, we multiply the last word output with the sentence state,
+        ##    and update the sentence state by multiplying it with -1
+        def step_func(sentence, sentence_state, word_state):
+            assert isinstance(sentence, list)
+
+            ### for each sentence, we use inner_step_func to accumulate its word embeddings
+            def inner_step_func(w, ws):
+                ### w is the current word emebdding
+                ### ws is the current word state
+                assert isinstance(w, torch.Tensor)
+                assert isinstance(ws, torch.Tensor)
+                ## return output and updated state
+                return [w + ws.mean(-1).unsqueeze(-1)], [ws]
+
+            outputs, word_states = rc.recurrent_group(
+                seq_inputs=[sentence],
+                insts=[],
+                init_states=[word_state],
+                step_func=inner_step_func)
+
+            last_outputs = torch.stack([o[-1] for o in outputs])
+            last_word_states = torch.stack([s[-1] for s in word_states])
+            ## we compute the output by multipying the sentence state
+            ## with the last word state
+            out = last_outputs * sentence_state
+            return [out], [sentence_state * -1, last_word_states]
+
+        outs, sentence_states, word_states \
+            = rc.recurrent_group(seq_inputs=[sentence_tensors],
+                                 insts=[],
+                                 init_states=[sentence_state_tensors,
+                                              word_state_tensors],
+                                 step_func=step_func)
+        self.assertTrue(
+            tensor_lists_equal(outs, [
+                torch.tensor([[-3.0, -6.0, -9.0, -12.0], [2.4, 4.8, 7.2, 9.6]
+                              ]), torch.tensor([[0.5, 1.0, 1.5, 2.0], [
+                                  -0.8, -1.6, -2.4, -3.2
+                              ], [0.5, 1.0, 1.5, 2.0]])
+            ]))
+        self.assertTrue(
+            tensor_lists_equal(sentence_states, [
+                torch.tensor([[2., 4., 6., 8.], [-2., -4., -6., -8.]]),
+                torch.tensor([[1., 2., 3., 4.], [-1., -2., -3., -4.],
+                              [1., 2., 3., 4.]])
+            ]))
+        self.assertTrue(
+            tensor_lists_equal(word_states, [
+                torch.tensor([[1., 1.], [1., 1.]]), torch.tensor(
+                    [[-1., -1.], [-1., -1.], [-1., -1.]])
+            ]))
 
 
 if __name__ == "__main__":

--- a/flare/framework/tests/test_recurrent.py
+++ b/flare/framework/tests/test_recurrent.py
@@ -1,0 +1,115 @@
+import flare.framework.recurrent as rc
+import unittest
+import numpy as np
+import torch
+
+
+def tensor_lists_equal(t1, t2):
+    """
+    Given two (nested) lists of tensors, return whether they are equal.
+    """
+    if isinstance(t1, torch.Tensor) and isinstance(t2, torch.Tensor):
+        return bool((t1 == t2).all().item())
+
+    assert isinstance(t1, list)
+    assert isinstance(t2, list)
+    assert len(t1) == len(t2)
+
+    for t1_, t2_ in zip(t1, t2):
+        if not tensor_lists_equal(t1_, t2_):
+            return False
+    return True
+
+
+class TestHierarchyTensorTranspose(unittest.TestCase):
+    def test_transpose(self):
+        data = [[[[3], [4], [5]], [[1], [2]], [[10], [2], [4], [5]]],
+                [[[3], [4], [5]], [[1], [2]]]]
+
+        ht = rc.make_hierarchy_of_tensors(data, "int64", "cpu", (1, ))
+        ht_ = rc.transpose(rc.transpose(ht))  ## this should convert back to ht
+        self.assertTrue(tensor_lists_equal(ht, ht_))
+
+
+class TestRecurrentGroup(unittest.TestCase):
+    def test_recurrent_group(self):
+        ## we first make a batch of temporal sequences of sentences
+        ## Let's suppose that each word has a 1d embedding
+        sentences = [## temporal sequence 1
+                     [[[0.3], [0.4], [0.5]],          ## sentence 1
+                      [[0.2], [0.2]],                 ## sentence 2
+                      [[1.0], [0.2], [0.4], [0.5]]],  ## sentence 3
+                     ## temporal sequence 2
+                     [[[0.3], [0.4], [0.5]],          ## sentence 4
+                      [[0.1], [0.2]]]                 ## sentence 5
+        ]
+        sentence_tensors = rc.make_hierarchy_of_tensors(sentences, "float32",
+                                                        "cpu", [1])
+
+        ## we then make a batch of temporal sequences of images
+        images = [## temporal sequence 1
+                  [[0, 1],                     ## image 1
+                   [1, 0],                     ## image 2
+                   [1, 1]],                    ## image 3
+                  ## temporal sequence 2
+                  [[0.1, 0.3],                 ## image 4
+                   [0, -1]]                    ## image 5
+        ]
+        image_tensors = rc.make_hierarchy_of_tensors(images, "float32", "cpu",
+                                                     [2])
+
+        states = [
+            [-1, -2, -3, -4],  ## temporal sequence 1
+            [-2, -4, -6, -8]  ## temporal sequence 2
+        ]
+        state_tensors = rc.make_hierarchy_of_tensors(states, "float32", "cpu",
+                                                     [4])
+
+        def step_func(sentence, image, state):
+            """
+            We have no `insts` and `states`
+            """
+            ## We compute the first output by doing outer product between the
+            ## average word embedding and the image embedding.
+            ## We compute the second output by adding the average word embedding
+            ## and the average image embedding.
+            ## We directly add the state mean value to the output
+            ## and update the state by multiplying it with -1.
+            assert isinstance(sentence, list)
+            assert isinstance(image, torch.Tensor)
+            assert isinstance(state, torch.Tensor)
+            sentence = torch.stack([sen.mean(0) for sen in sentence])
+            assert sentence.size()[0] == image.size()[0]
+
+            mean_state = state.mean(-1).unsqueeze(-1)
+            out1 = torch.bmm(sentence.unsqueeze(2), image.unsqueeze(1)).view(
+                sentence.size()[0], -1) + mean_state
+            out2 = sentence + image.mean(-1).unsqueeze(-1) + mean_state
+            return [out1, out2], [state * -1]
+
+        outs = rc.recurrent_group([sentence_tensors, image_tensors], [],
+                                  [state_tensors], step_func)
+
+        self.assertTrue(
+            tensor_lists_equal(
+                outs,
+                [
+                    [
+                        torch.tensor([[-2.5000, -2.1000], [2.7000, 2.5000],
+                                      [-1.9750, -1.9750]]),
+                        torch.tensor([[-4.9600, -4.8800], [5.0000, 4.8500]])
+                    ],  ## out1
+                    [
+                        torch.tensor([[-1.6000], [3.2000], [-0.9750]]),
+                        torch.tensor([[-4.4000], [4.6500]])
+                    ],  ## out2
+                    [
+                        torch.tensor([[1., 2., 3., 4.], [-1., -2., -3., -4.],
+                                      [1., 2., 3., 4.]]),
+                        torch.tensor([[2., 4., 6., 8.], [-2., -4., -6., -8.]])
+                    ]  ## state
+                ]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR tries to make hierarchical sequences easier in PyTorch. To this end, I implement a recurrent_group function which strips the sequence information one by one. The user needs to provide a step function to recurrent_group. I use the nested list information as the sequence info. The rest implementation is quite similar to the counterpart in PaddlePaddle.

recurrent_group has not yet been integrated into ComputationTask yet. 